### PR TITLE
refactor: SSL 인증서 발급 및 쿠키 cross-domain 설정

### DIFF
--- a/infra/development/docker/docker-compose.yml
+++ b/infra/development/docker/docker-compose.yml
@@ -9,7 +9,20 @@ services:
       - "443:443"
     restart: always
     volumes:
-      - ../nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/:/etc/nginx/
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+    networks:
+      - onepiece-network
+
+  certbot:
+    image: certbot/certbot
+    container_name: onepiece-certbot
+    volumes:
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
     networks:
       - onepiece-network
 

--- a/infra/development/nginx/nginx.conf
+++ b/infra/development/nginx/nginx.conf
@@ -1,7 +1,3 @@
-user  nginx;
-worker_processes  auto;
-
-error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
 events {
@@ -9,7 +5,6 @@ events {
 }
 
 http {
-    include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
@@ -25,17 +20,35 @@ http {
     upstream api {
         server onepiece-api:8080;
     }
+    server {
+        listen 443 ssl;
+        server_name dev.critix.kr;
+        server_tokens off;
 
+            ssl_certificate /etc/letsencrypt/live/dev.critix.kr/fullchain.pem;
+            ssl_certificate_key /etc/letsencrypt/live/dev.critix.kr/privkey.pem;
+            include /etc/letsencrypt/options-ssl-nginx.conf;
+            ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+            location / {
+                proxy_pass  http://api;
+                proxy_set_header    Host                $http_host;
+                proxy_set_header    X-Real-IP           $remote_addr;
+            proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+            }
+        }
     server {
         listen 80;
-        server_name dev-api.critix.kr;
+            server_name dev.critix.kr;
+        server_tokens off;
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
 
         location / {
-            proxy_pass http://api/;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            return 301 https://$host$request_uri;
         }
     }
+
 }

--- a/src/main/java/depromeet/onepiece/common/auth/application/jwt/TokenInjector.java
+++ b/src/main/java/depromeet/onepiece/common/auth/application/jwt/TokenInjector.java
@@ -30,7 +30,7 @@ public class TokenInjector {
     cookie.setHttpOnly(securityProperties.cookie().httpOnly());
     cookie.setDomain(securityProperties.cookie().domain());
     cookie.setSecure(securityProperties.cookie().secure());
-    cookie.setAttribute("SameSite", "Lax");
+    cookie.setAttribute("SameSite", "None");
     response.addCookie(cookie);
   }
 
@@ -41,7 +41,7 @@ public class TokenInjector {
     cookie.setHttpOnly(securityProperties.cookie().httpOnly());
     cookie.setDomain(securityProperties.cookie().domain());
     cookie.setSecure(securityProperties.cookie().secure());
-    cookie.setAttribute("SameSite", "Lax");
+    cookie.setAttribute("SameSite", "None");
     response.addCookie(cookie);
   }
 }

--- a/src/main/java/depromeet/onepiece/common/config/SecurityConfig.java
+++ b/src/main/java/depromeet/onepiece/common/config/SecurityConfig.java
@@ -100,7 +100,7 @@ public class SecurityConfig {
       CorsConfiguration config = new CorsConfiguration();
       config.setAllowedHeaders(Collections.singletonList("*"));
       config.setAllowedMethods(Collections.singletonList("*"));
-      config.setAllowedOriginPatterns(List.of("http://localhost:3000"));
+      config.setAllowedOriginPatterns(List.of("http://localhost:3000", "https://dev.critix.kr"));
       config.setAllowCredentials(true);
       return config;
     };

--- a/src/main/java/depromeet/onepiece/common/config/SwaggerConfig.java
+++ b/src/main/java/depromeet/onepiece/common/config/SwaggerConfig.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springdoc.core.utils.SpringDocUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -32,9 +31,6 @@ public class SwaggerConfig {
   private static final String GITHUB_URL = "https://github.com/depromeet/16th-team1-BE";
   private final Environment environment;
 
-  @Value("${springdoc.server-url}")
-  private String serverUrl;
-
   private final Map<String, String> PROFILE_SERVER_URL_MAP = new HashMap<>();
 
   static {
@@ -44,7 +40,7 @@ public class SwaggerConfig {
   @PostConstruct
   public void init() {
     PROFILE_SERVER_URL_MAP.put("local", "http://localhost:8080");
-    PROFILE_SERVER_URL_MAP.put("dev", "http://" + serverUrl + ":8080");
+    PROFILE_SERVER_URL_MAP.put("dev", "https://dev.critix.kr");
   }
 
   @Bean

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,11 @@
 spring:
+  security:
+    login-url: ${LOGIN_URL:/login}
+    redirect-url: ${REDIRECT_URL:/login}
+    cookie:
+      domain: ${COOKIE_DOMAIN:localhost}
+      secure: ${COOKIE_SECURE:true}
+      http-only: ${COOKIE_HTTP_ONLY:false}
   data:
     mongodb:
       uri: ${MONGODB_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,8 @@ spring:
     login-url: ${LOGIN_URL}
     redirect-url: ${REDIRECT_URL}
     cookie:
-      domain: ${COOKIE_DOMAIN}
-      secure: ${COOKIE_SECURE}
+      domain: ${COOKIE_DOMAIN:critix.kr}
+      secure: ${COOKIE_SECURE:true}
       http-only: ${COOKIE_HTTP_ONLY:false}
     jwt:
       secret_key: ${JWT_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,6 @@ spring:
 springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
-  server-url: ${SERVER_URL:localhost}
   swagger-ui:
     operations-sorter: alpha
     tags-sorter: alpha


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #65 

## 💡 작업내용

- [x] SSL 인증서 발급 후 https 적용
- [x] 클라이언트 localhost 테스트를 위해 쿠키  cross-domain 설정
