### PR TITLE
fix: production 배포 파이프라인 버그 수정

### DIFF
--- a/.github/workflows/DeployToProd.yml
+++ b/.github/workflows/DeployToProd.yml
@@ -11,24 +11,26 @@ jobs:
     runs-on: ubuntu-22.04
     environment: production
     permissions:
+      id-token: write
       contents: write
 
     steps:
       - name: "레포지토리에서 체크아웃한다."
         uses: actions/checkout@v4
 
-      - name: "브랜치에서 버전 정보를 추출한다."
-        run: echo "##[set-output name=version;]$(echo '${{ github.ref }}' | egrep -o 'release/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})' | sed 's/release\///')"
-        id: extract_version_name
+      - name: "auto_tagging 트리거를 동작한다"
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: "릴리즈 태그를 생성한다."
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.extract_version_name.outputs.version }}
-          release_name: ${{ steps.extract_version_name.outputs.version }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
         if: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: "JDK 21을 설정한다."
@@ -53,11 +55,15 @@ jobs:
 
       - name: "도커 허브에 빌드된 이미지를 푸시한다."
         run: |
-          VERSION=${{ steps.extract_version_name.outputs.version }}
-          docker build -t ${{ secrets.DOCKER_USERNAME }}/critix-server:$VERSION .
-          docker tag ${{ secrets.DOCKER_USERNAME }}/critix-server:$VERSION ${{ secrets.DOCKER_USERNAME }}/critix-server:latest
-          docker push ${{ secrets.DOCKER_USERNAME }}/critix-server:$VERSION
-          docker push ${{ secrets.DOCKER_USERNAME }}/critix-server:latest
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            VERSION=${{ steps.tag_version.outputs.new_tag }}
+            docker build -t ${{ secrets.DOCKER_USERNAME }}/critix-server:$VERSION .
+            docker tag ${{ secrets.DOCKER_USERNAME }}/critix-server:$VERSION ${{ secrets.DOCKER_USERNAME }}/critix-server:latest
+            docker push ${{ secrets.DOCKER_USERNAME }}/critix-server:$VERSION
+          else
+            docker build -t ${{ secrets.DOCKER_USERNAME }}/critix-server:latest .
+          fi
+            docker push ${{ secrets.DOCKER_USERNAME }}/critix-server:latest
 
   deploy:
     needs: build


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #138 

## 💡 작업내용

- 릴리즈 태그 Auto_Tagging 라이브러리 설정
- workflow_dispatch로 배포 시 `latest`만 도커 허브에 푸시

## 📸 스크린샷(선택)

## 📝 기타

- `auto_tagging` 라이브러리를 활용하면, 커밋 이력에 따라 적절한 릴리즈 태그가 자동으로 생성됩니다.  
- 따라서, Git Flow를 엄격하게 준수할 필요가 없다면 `develop` 브랜치에서 `main` 브랜치로 직접 PR을 생성하고 머지하는 방식도 가능합니다.
- 확인 해주세요 @suker80 @cowboysj 
